### PR TITLE
Fix failure when belongsTo is resolved to null

### DIFF
--- a/addon/macros/has-many-through.js
+++ b/addon/macros/has-many-through.js
@@ -37,7 +37,9 @@ export default function (...args) {
 
           all.pushObject(
             prom.then((childrenOfChild) => {
-              res.pushObjects(childrenOfChild.toArray ? childrenOfChild.toArray() : [childrenOfChild]);
+              if (childrenOfChild) {
+                res.pushObjects(childrenOfChild.toArray ? childrenOfChild.toArray() : [childrenOfChild]);
+              }
             })
           );
         });

--- a/tests/dummy/app/models/child.js
+++ b/tests/dummy/app/models/child.js
@@ -3,6 +3,7 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   childrenOfChild: DS.hasMany('childOfChild'),
   childrenOfChildArray: [],
+  singleChildOfChild: DS.belongsTo('childOfChild'),
   simpleArray: [],
   filterMe: true
 });

--- a/tests/dummy/app/models/parent.js
+++ b/tests/dummy/app/models/parent.js
@@ -10,6 +10,8 @@ export default DS.Model.extend({
   childrenOfChild: hasManyThrough('children'),
   childrenOfChildren: hasManyThrough('children', 'childrenOfChild'),
   childrenOfChildArray: hasManyThrough('children'),
+  singleChildOfChild: hasManyThrough('children'),
+  singleChildOfChildren: hasManyThrough('children', 'singleChildOfChild'),
   simpleArray: hasManyThroughNonObject('children'),
   filteredChildren: computed.filterBy('children', 'filterMe', true),
   concatArray: concat('filteredChildren', 'simpleArray')

--- a/tests/unit/models/parent-test.js
+++ b/tests/unit/models/parent-test.js
@@ -16,6 +16,67 @@ test('it exists', function (assert) {
   assert.ok(!!model);
 });
 
+test('hasManyThrough on belongsTo of one hasMany', function (assert) {
+  let store = this.store(),
+    childOfChild1, child1, child2, parent;
+  parent = this.subject();
+  Ember.run(() => {
+    childOfChild1 = store.createRecord('child-of-child');
+    child1 = store.createRecord('child');
+    child2 = store.createRecord('child');
+    parent.get('children').then((children) => {
+      let arrayOfChildOfChild = [childOfChild1];
+
+      child1.set('singleChildOfChild', childOfChild1);
+      children.pushObject(child1);
+      parent.get('singleChildOfChild').then((res) => {
+        assert.deepEqual(
+          res,
+          arrayOfChildOfChild,
+          'the hasManyThrough property forwards the belongsTo of one hasMany child'
+        );
+        assert.deepEqual(
+          parent.get('singleChildOfChild.content'),
+          arrayOfChildOfChild,
+          'the hasManyThrough property is a promiseArray'
+        );
+      });
+      parent.get('singleChildOfChildren').then((res) => {
+        assert.deepEqual(
+          res,
+          arrayOfChildOfChild,
+          'the hasManyThrough property can be aliased to another property name'
+        );
+      });
+      Ember.RSVP.all([
+        parent.get('singleChildOfChild'),
+        parent.get('singleChildOfChildren')
+      ]).then(() => {
+        children.pushObject(child2);
+        parent.get('singleChildOfChild').then((res) => {
+          assert.deepEqual(
+            res,
+            arrayOfChildOfChild,
+            'the hasManyThrough property forwards the belongsTo of one hasMany child after adding a record without related child on belongsTo'
+          );
+          assert.deepEqual(
+            parent.get('singleChildOfChild.content'),
+            arrayOfChildOfChild,
+            'the hasManyThrough property is a promiseArray after adding a record without related child on belongsTo'
+          );
+        });
+        parent.get('singleChildOfChildren').then((res) => {
+          assert.deepEqual(
+            res,
+            arrayOfChildOfChild,
+            'the hasManyThrough property can be aliased to another property name after adding a record without related child on belongsTo'
+          );
+        });
+      });
+    });
+  });
+});
+
 test('hasManyThrough on hasMany of one hasMany', function (assert) {
   let store = this.store(),
     childOfChild1, childOfChild2, child, parent;


### PR DESCRIPTION
In case `belongsTo` pointed to by `hasManyThrough` is resolved to `null` there is an exception at https://github.com/britishgas-engineering/ember-data-has-many-through/blob/master/addon/macros/has-many-through.js#L40 
```
null is not an object (evaluating 'childrenOfChild.toArray')
```
This PR fixes that.