### PR TITLE
Test failures due to child object in isDestroying or isDestroyed state 

### DIFF
--- a/addon/macros/has-many-through.js
+++ b/addon/macros/has-many-through.js
@@ -54,6 +54,9 @@ export default function (...args) {
         });
         return RSVP.all(all).then(() => {
           children.forEach((child) => {
+            if (child.isDestroyed || child.isDestroying) {
+              return true;
+            }
             // add observer for when a childOfChild is added / destroyed
             if (isBelongsTo) {
               //child.removeObserver(`${childOfChildKey}.isDeleted`, self, observerForChildOfChild);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-has-many-through",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A small Addon to forward hasMany of hasMany relationships to the grand-parent.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Test failures with message 'Attempted to register a destructor with an object that is already destroying or destroyed'. This is  due to child object in isDestroying or isDestroyed state and hence need to capture and avoid as generally done in this case.
Required for ember-data >3.27.1